### PR TITLE
Add support for asymmetric signing algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tags
 tq:q
 *DoNotCommit*
 .sbtopts
+.metals

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ case class AuthUser(id: Long, name: String)
 val authenticate: JwtToken => JwtClaim => IO[Option[AuthUser]] =
   token => claim => AuthUser(123L, "joe").some.pure[IO]
 
-val jwtAuth    = JwtAuth(JwtSecretKey("53cr3t"), JwtAlgorithm.HS256)
+val jwtAuth    = JwtAuth.hmac("53cr3t", JwtAlgorithm.HS256)
 val middleware = JwtAuthMiddleware[IO, AuthUser](jwtAuth, authenticate)
 
 val routes: AuthedRoutes[AuthUser, IO] = ???

--- a/core/src/main/scala/dev/profunktor/auth/jwt.scala
+++ b/core/src/main/scala/dev/profunktor/auth/jwt.scala
@@ -3,26 +3,43 @@ package dev.profunktor.auth
 import cats._
 import cats.implicits._
 import pdi.jwt._
-import pdi.jwt.algorithms.JwtHmacAlgorithm
+import pdi.jwt.algorithms.{ JwtAsymmetricAlgorithm, JwtECDSAAlgorithm, JwtHmacAlgorithm, JwtRSAAlgorithm }
 
 object jwt {
 
   case class JwtToken(value: String) extends AnyVal
-  case class JwtSecretKey(value: String) extends AnyVal
 
-  case class JwtAuth(
-      secretKey: JwtSecretKey,
-      jwtAlgorithm: JwtHmacAlgorithm
-  )
+  case class JwtSecretKey(value: String) extends AnyVal
+  case class JwtPublicKey(value: String) extends AnyVal
+
+  sealed trait JwtAuth
+  case class JwtSymmetricAuth(secretKey: JwtSecretKey, jwtAlgorithms: Seq[JwtHmacAlgorithm]) extends JwtAuth
+  case class JwtAsymmetricAuth(publicKey: JwtPublicKey, jwtAlgorithms: Seq[JwtAsymmetricAlgorithm]) extends JwtAuth
+  object JwtAuth {
+    def hmac(secretKey: String, algorithm: JwtHmacAlgorithm): JwtSymmetricAuth =
+      JwtSymmetricAuth(JwtSecretKey(secretKey), Seq(algorithm))
+    def hmac(secretKey: String, algorithms: Seq[JwtHmacAlgorithm] = JwtAlgorithm.allHmac()): JwtSymmetricAuth =
+      JwtSymmetricAuth(JwtSecretKey(secretKey), algorithms)
+    def rsa(publicKey: String, algorithm: JwtRSAAlgorithm): JwtAsymmetricAuth =
+      JwtAsymmetricAuth(JwtPublicKey(publicKey), Seq(algorithm))
+    def rsa(publicKey: String, algorithms: Seq[JwtRSAAlgorithm] = JwtAlgorithm.allRSA()): JwtAsymmetricAuth =
+      JwtAsymmetricAuth(JwtPublicKey(publicKey), algorithms)
+    def ecdsa(publicKey: String, algorithm: JwtECDSAAlgorithm): JwtAsymmetricAuth =
+      JwtAsymmetricAuth(JwtPublicKey(publicKey), Seq(algorithm))
+    def ecdsa(publicKey: String, algorithms: Seq[JwtECDSAAlgorithm] = JwtAlgorithm.allECDSA()): JwtAsymmetricAuth =
+      JwtAsymmetricAuth(JwtPublicKey(publicKey), algorithms)
+  }
 
   // ----- Common JWT Functions -----
 
-  def jwtDecode[F[_]: ApplicativeError[?[_], Throwable]](
+  def jwtDecode[F[_]: ApplicativeError[*[_], Throwable]](
       jwtToken: JwtToken,
-      jwtSecretKey: JwtSecretKey,
-      jwtAlgorithm: JwtHmacAlgorithm
+      jwtAuth: JwtAuth
   ): F[JwtClaim] =
-    Jwt.decode(jwtToken.value, jwtSecretKey.value, Seq(jwtAlgorithm)).liftTo[F]
+    (jwtAuth match {
+      case JwtSymmetricAuth(secretKey, algorithms)  => Jwt.decode(jwtToken.value, secretKey.value, algorithms)
+      case JwtAsymmetricAuth(publicKey, algorithms) => Jwt.decode(jwtToken.value, publicKey.value, algorithms)
+    }).liftTo[F]
 
   def jwtEncode[F[_]: Applicative](
       jwtClaim: JwtClaim,
@@ -30,5 +47,12 @@ object jwt {
       jwtAlgorithm: JwtHmacAlgorithm
   ): F[JwtToken] =
     JwtToken(Jwt.encode(jwtClaim, jwtSecretKey.value, jwtAlgorithm)).pure[F]
+
+  def jwtEncode[F[_]: Applicative](
+      jwtClaim: JwtClaim,
+      jwtPublicKey: JwtPublicKey,
+      jwtAlgorithm: JwtAsymmetricAlgorithm
+  ): F[JwtToken] =
+    JwtToken(Jwt.encode(jwtClaim, jwtPublicKey.value, jwtAlgorithm)).pure[F]
 
 }

--- a/core/src/test/scala/dev/profunktor/auth/JwtAuthMiddlewareSpec.scala
+++ b/core/src/test/scala/dev/profunktor/auth/JwtAuthMiddlewareSpec.scala
@@ -59,12 +59,12 @@ trait JwtFixture {
       if (extractId(claim.content) == 123L) AuthUser(123L, "joe").some.pure[IO]
       else none[AuthUser].pure[IO]
 
-  val jwtAuth    = JwtAuth(JwtSecretKey("53cr3t"), JwtAlgorithm.HS256)
+  val jwtAuth    = JwtAuth.hmac("53cr3t", JwtAlgorithm.HS256)
   val middleware = JwtAuthMiddleware[IO, AuthUser](jwtAuth, authenticate)
 
-  val adminToken  = Jwt.encode(JwtClaim("{123}"), jwtAuth.secretKey.value, JwtAlgorithm.HS256)
-  val noUserToken = Jwt.encode(JwtClaim("{666}"), jwtAuth.secretKey.value, JwtAlgorithm.HS256)
-  val randomToken = Jwt.encode(JwtClaim("{000}"), "secret", JwtAlgorithm.HS256)
+  val adminToken  = Jwt.encode(JwtClaim("{123}"), jwtAuth.secretKey.value, jwtAuth.jwtAlgorithms.head)
+  val noUserToken = Jwt.encode(JwtClaim("{666}"), jwtAuth.secretKey.value, jwtAuth.jwtAlgorithms.head)
+  val randomToken = Jwt.encode(JwtClaim("{000}"), "secret", jwtAuth.jwtAlgorithms.head)
 
   val rootReq         = Request[IO](Method.GET, Uri.unsafeFromString("/"))
   val adminReqNoToken = Request[IO](Method.GET, Uri.unsafeFromString("/admin"))

--- a/site/src/main/tut/example.md
+++ b/site/src/main/tut/example.md
@@ -11,7 +11,7 @@ case class AuthUser(id: Long, name: String)
 val authenticate: JwtToken => JwtClaim => IO[Option[AuthUser]] =
   token => claim => AuthUser(123L, "joe").some.pure[IO]
 
-val jwtAuth    = JwtAuth(JwtSecretKey("53cr3t"), JwtAlgorithm.HS256)
+val jwtAuth    = JwtAuth.hmac("53cr3t", JwtAlgorithm.HS256)
 val middleware = JwtAuthMiddleware[IO, AuthUser](jwtAuth, authenticate)
 
 val routes: AuthedRoutes[AuthUser, IO] = null


### PR DESCRIPTION
This PR aims to add support for asymmetric signing algorithms by generalizing the JwtAuth into an ADT (with some smart constructors) which covers all the signing algorithms already supported by the jwt-scala library. It also adapts decoding/encoding functions and middleware accordingly.

Closes #14
