### PR TITLE
Added a scala 3 cross-build

### DIFF
--- a/core/src/main/scala/dev/profunktor/auth/AsymmetricKeys.scala
+++ b/core/src/main/scala/dev/profunktor/auth/AsymmetricKeys.scala
@@ -1,10 +1,10 @@
 package dev.profunktor.auth
 
 import cats.ApplicativeThrow
-import cats.syntax.all._
+import cats.syntax.all.*
 import java.security.{ KeyFactory, PrivateKey, PublicKey }
 import java.security.spec.{ PKCS8EncodedKeySpec, X509EncodedKeySpec }
-import pdi.jwt.algorithms._
+import pdi.jwt.algorithms.*
 import pdi.jwt.{ JwtBase64, JwtUtils }
 
 final case class PKCS8(value: String) extends AnyVal

--- a/core/src/main/scala/dev/profunktor/auth/headers.scala
+++ b/core/src/main/scala/dev/profunktor/auth/headers.scala
@@ -1,7 +1,7 @@
 package dev.profunktor.auth
 
-import jwt._
-import org.http4s._
+import jwt.*
+import org.http4s.*
 import org.http4s.Credentials.Token
 import org.http4s.headers.Authorization
 

--- a/core/src/main/scala/dev/profunktor/auth/jwt.scala
+++ b/core/src/main/scala/dev/profunktor/auth/jwt.scala
@@ -1,8 +1,8 @@
 package dev.profunktor.auth
 
-import cats._
-import cats.syntax.all._
-import pdi.jwt._
+import cats.*
+import cats.syntax.all.*
+import pdi.jwt.*
 import pdi.jwt.algorithms.JwtHmacAlgorithm
 
 object jwt {

--- a/core/src/main/scala/dev/profunktor/auth/middleware.scala
+++ b/core/src/main/scala/dev/profunktor/auth/middleware.scala
@@ -2,12 +2,12 @@ package dev.profunktor.auth
 
 import cats.MonadThrow
 import cats.data.{ Kleisli, OptionT }
-import cats.syntax.all._
-import jwt._
+import cats.syntax.all.*
+import jwt.*
 import org.http4s.{ AuthedRoutes, Request }
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.AuthMiddleware
-import pdi.jwt._
+import pdi.jwt.*
 import pdi.jwt.exceptions.JwtException
 
 object JwtAuthMiddleware {
@@ -15,7 +15,7 @@ object JwtAuthMiddleware {
       jwtAuth: JwtAuth,
       authenticate: JwtToken => JwtClaim => F[Option[A]]
   ): AuthMiddleware[F, A] = {
-    val dsl = new Http4sDsl[F] {}; import dsl._
+    val dsl = new Http4sDsl[F] {}; import dsl.*
 
     val onFailure: AuthedRoutes[String, F] =
       Kleisli(req => OptionT.liftF(Forbidden(req.context)))

--- a/core/src/test/scala/dev/profunktor/auth/JwtAuthMiddlewareSuite.scala
+++ b/core/src/test/scala/dev/profunktor/auth/JwtAuthMiddlewareSuite.scala
@@ -5,10 +5,10 @@ import scala.util.Try
 import cats.data.OptionT
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import cats.syntax.all._
+import cats.syntax.all.*
 
 import munit.FunSuite
-import org.http4s._
+import org.http4s.*
 
 class JwtAuthMiddlewareSpec extends FunSuite with JwtFixture {
 
@@ -46,9 +46,9 @@ class JwtAuthMiddlewareSpec extends FunSuite with JwtFixture {
 object TestUsers {}
 
 trait JwtFixture {
-  import dev.profunktor.auth.jwt._
-  import org.http4s.dsl.io._
-  import pdi.jwt._
+  import dev.profunktor.auth.jwt.*
+  import org.http4s.dsl.io.*
+  import pdi.jwt.*
 
   case class AuthUser(id: Long, name: String)
 


### PR DESCRIPTION
Hello 👋 

Added scala 3 to the cross build. The changes necessary were not big; the only one that I'm unhappy with is `assertThrows`; `ClassTag` cannot be used for type checks anymore in scala 3, so in order to keep it as it was I would've had to put `assertThrows` into its own file, and then make version-specific copies of that file, which did not seem great. I "solved" it with an explicit partial function requirement.

Let me know if you need anything else!

resolves #296 