### PR TITLE
Middleware api

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ import org.http4s._
 case class AuthUser(id: Long, name: String)
 
 // i.e. retrieve user from database
-val authenticate: JwtToken => JwtClaim => IO[Option[AuthUser]] =
-  token => claim => AuthUser(123L, "joe").some.pure[IO]
+val authenticate: JwtToken => IO[Option[AuthUser]] =
+  token => AuthUser(123L, "joe").some.pure[IO]
 
 val jwtAuth    = JwtAuth.hmac("53cr3t", JwtAlgorithm.HS256)
 val middleware = JwtAuthMiddleware[IO, AuthUser](jwtAuth, authenticate)


### PR DESCRIPTION
I think it is more intuitive to use function with signature `JwtToken => F[Option[A]]` instad of `JwtToken => JwtClaim => F[Option[A]]`. 