### PR TITLE
Update maven central badge to new url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ http4s-jwt-auth
 
 [![CI Status](https://github.com/profunktor/http4s-jwt-auth/workflows/Scala/badge.svg)](https://github.com/profunktor/http4s-jwt-auth/actions)
 [![Gitter Chat](https://badges.gitter.im/profunktor-dev/http4s-jwt-auth.svg)](https://gitter.im/profunktor-dev/http4s-jwt-auth)
-[![Maven Central](https://img.shields.io/maven-central/v/dev.profunktor/http4s-jwt-auth_2.12.svg)](http://search.maven.org/#search%7Cga%7C1%7Chttp4s-jwt-auth) <a href="https://typelevel.org/cats/"><img src="https://raw.githubusercontent.com/typelevel/cats/c23130d2c2e4a320ba4cde9a7c7895c6f217d305/docs/src/main/resources/microsite/img/cats-badge.svg" height="40px" align="right" alt="Cats friendly" /></a>
+[![Maven Central](https://img.shields.io/maven-central/v/dev.profunktor/http4s-jwt-auth_2.12.svg)](https://central.sonatype.com/search?q=dev.profunktor%2520http4s-jwt-auth) <a href="https://typelevel.org/cats/"><img src="https://raw.githubusercontent.com/typelevel/cats/c23130d2c2e4a320ba4cde9a7c7895c6f217d305/docs/src/main/resources/microsite/img/cats-badge.svg" height="40px" align="right" alt="Cats friendly" /></a>
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-brightgreen.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 
 Opinionated [JWT](https://tools.ietf.org/html/rfc7519) authentication library for [http4s](https://http4s.org/).


### PR DESCRIPTION
http://search.maven.org has been deprecated and old link was redirected.