### PR TITLE
Change representation of PrivateKey to not use String

### DIFF
--- a/core/src/main/scala/dev/profunktor/auth/jwt.scala
+++ b/core/src/main/scala/dev/profunktor/auth/jwt.scala
@@ -71,7 +71,7 @@ object jwt {
       JwtSymmetricAuth(JwtSecretKey(secretKey.toArray[Char]), algorithms)
     def hmac(
         secretKey: Array[Char],
-        algorithms: Seq[JwtHmacAlgorithm] /* = JwtAlgorithm.allHmac() */
+        algorithms: Seq[JwtHmacAlgorithm]
     ): JwtSymmetricAuth =
       JwtSymmetricAuth(JwtSecretKey(secretKey), algorithms)
   }

--- a/core/src/main/scala/dev/profunktor/auth/jwt.scala
+++ b/core/src/main/scala/dev/profunktor/auth/jwt.scala
@@ -66,7 +66,7 @@ object jwt {
       JwtSymmetricAuth(JwtSecretKey(secretKey.toArray[Char]), Seq(algorithm))
     def hmac(secretKey: Array[Char], algorithm: JwtHmacAlgorithm): JwtSymmetricAuth =
       JwtSymmetricAuth(JwtSecretKey(secretKey), Seq(algorithm))
-    @deprecated(message = "use of string to hold secret keys is deprecated", since = "1.x")
+    @deprecated(message = "use of string to hold secret keys is deprecated and potentially unsafe", since = "2.x")
     def hmac(secretKey: String, algorithms: Seq[JwtHmacAlgorithm] = JwtAlgorithm.allHmac()): JwtSymmetricAuth =
       JwtSymmetricAuth(JwtSecretKey(secretKey.toArray[Char]), algorithms)
     def hmac(

--- a/core/src/main/scala/dev/profunktor/auth/jwt.scala
+++ b/core/src/main/scala/dev/profunktor/auth/jwt.scala
@@ -61,7 +61,7 @@ object jwt {
   case class JwtAsymmetricAuth(publicKey: JwtPublicKey) extends JwtAuth
   object JwtAuth {
     def noValidation: JwtAuth = JwtNoValidation
-    @deprecated(message = "use of string to hold secret keys is deprecated", since = "1.x")
+    @deprecated(message = "use of string to hold secret keys is deprecated and potentially unsafe", since = "2.x")
     def hmac(secretKey: String, algorithm: JwtHmacAlgorithm): JwtSymmetricAuth =
       JwtSymmetricAuth(JwtSecretKey(secretKey.toArray[Char]), Seq(algorithm))
     def hmac(secretKey: Array[Char], algorithm: JwtHmacAlgorithm): JwtSymmetricAuth =

--- a/core/src/test/scala/dev/profunktor/auth/JwtAuthMiddlewareSuite.scala
+++ b/core/src/test/scala/dev/profunktor/auth/JwtAuthMiddlewareSuite.scala
@@ -79,11 +79,11 @@ trait JwtFixture {
       if (extractId(claim.content) == 123L) AuthUser(123L, "joe").some.pure[IO]
       else none[AuthUser].pure[IO]
 
-  val jwtAuth    = JwtAuth.hmac("53cr3t", JwtAlgorithm.HS256)
+  val jwtAuth    = JwtAuth.hmac("53cr3t".toArray[Char], JwtAlgorithm.HS256)
   val middleware = JwtAuthMiddleware[IO, AuthUser](jwtAuth, authenticate)
 
-  val adminToken  = Jwt.encode(JwtClaim("{123}"), jwtAuth.secretKey.value, jwtAuth.jwtAlgorithms.head)
-  val noUserToken = Jwt.encode(JwtClaim("{666}"), jwtAuth.secretKey.value, jwtAuth.jwtAlgorithms.head)
+  val adminToken  = Jwt.encode(JwtClaim("{123}"), jwtAuth.secretKey.value.mkString, jwtAuth.jwtAlgorithms.head)
+  val noUserToken = Jwt.encode(JwtClaim("{666}"), jwtAuth.secretKey.value.mkString, jwtAuth.jwtAlgorithms.head)
   val randomToken = Jwt.encode(JwtClaim("{000}"), "secret", jwtAuth.jwtAlgorithms.head)
 
   val rootReq         = Request[IO](Method.GET, Uri.unsafeFromString("/"))


### PR DESCRIPTION
Changing the JwtSecretKey class to use an Array of Characters, byte array or PrivateKey.