### PR TITLE
fix sonatype publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import Dependencies._
 import microsites.ExtraMdFileConfig
+import xerial.sbt.Sonatype.sonatypeCentralHost
 
 ThisBuild / organizationName := "ProfunKtor"
 ThisBuild / crossScalaVersions := List("2.12.19", "2.13.14", "3.3.3")
@@ -17,6 +18,8 @@ ThisBuild / developers := List(
     url("https://gvolpe.com")
   )
 )
+
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 
 def maxClassFileName(v: String) = CrossVersion.partialVersion(v) match {
   case Some((2, 13)) | Some((3, _)) => List.empty[String]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
 resolvers += Classpaths.sbtPluginReleases
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
+resolvers += "OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.github.sbt"    % "sbt-ci-release" % "1.5.12+38-6b30fb12-SNAPSHOT")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"   % "3.11.0")
 addSbtPlugin("org.typelevel"     % "sbt-tpolecat"   % "0.5.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"     % "5.10.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"   % "2.5.2")


### PR DESCRIPTION
Not entirely sure this is needed, but a few things I followed here:

- Docs here adding Sonatype Central: https://github.com/xerial/sbt-sonatype/pull/474
- Explicitly add this new version of `sbt-sonatype` published two weeks ago.
- Add latest snapshot of `sbt-ci-release` as I'm not sure it supports the latest `sbt-sonatype`: https://github.com/sbt/sbt-ci-release/issues/294

I'll try to re-run the publishing job with the new credentials before merging this. If it doesn't work, we can try this.

Fixes #453 